### PR TITLE
Look for cargo.exe if on Windows.

### DIFF
--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
@@ -1,5 +1,6 @@
 package com.github.willir.rust
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
@@ -39,9 +40,10 @@ class CargoNdkBuildTask extends DefaultTask {
     }
 
     private void buildTarget(RustTargetType target) {
-        if (!isFoundInPath("cargo")) {
+        def cargo = Os.isFamily(Os.FAMILY_WINDOWS) ? "cargo.exe" : "cargo"
+        if (!isFoundInPath(cargo)) {
             throw new GradleException(
-                    "Cannot find 'cargo' executable in PATH: " + System.getenv("PATH"))
+                    "Cannot find '" + cargo + "' executable in PATH: " + System.getenv("PATH"))
         }
 
         int ndkVersion = getNdkVersion(target)


### PR DESCRIPTION
I haven't been able to test this because I can't find instructions for how to run a Gradle plugin from local sources that actually work. Everything is outdated. That said, I don't see why it shouldn't, or why it wouldn't at least get us past this particular breakage. If you can tell me how you test this locally, I'll gladly do so and report back. Thanks!