### PR TITLE
Update to work with cargo-ndk 2.0.0+

### DIFF
--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
@@ -45,7 +45,7 @@ class CargoNdkBuildTask extends DefaultTask {
 
         def cmd = ["cargo", "ndk",
                    "--target", target.rustTarget,
-                   "--android-platform", ndkVersion.toString(),
+                   "--platform", ndkVersion.toString(),
                    "--", "build"]
         if (config.offline) {
             cmd.add("--offline")


### PR DESCRIPTION
Still seems to work fine on cargo-ndk 1.0.0

Resolves #11 

I looked into checking the cargo-ndk version but it doesn't seem to output a version number at all.