### PR TITLE
add extraCargoNdkArguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,10 @@
 buildscript {
-    ext.plugin_version = '0.3.4'
-
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,17 +1,20 @@
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'com.gradle.plugin-publish' version '1.0.0'
 }
 
-version = "0.3.4"
-group = "com.github.willir.rust"
-
 gradlePlugin {
+    // website = 'https://github.com/laptou/cargo-ndk-android-gradle'
+    // vcsUrl = 'https://github.com/laptou/cargo-ndk-android-gradle.git'
+
     plugins {
         cargoNdkAndroidPlugin {
-            id = 'com.github.willir.rust.cargo-ndk-android'
+            id = 'com.github.laptou.cargo-ndk-android'
             implementationClass = 'com.github.willir.rust.CargoNdkBuildPlugin'
+            group = "com.github.laptou"
+            version = "0.4.0"
+            // tags.set(['rust', 'cargo', 'cargo-ndk', 'android'])
         }
     }
 }
@@ -19,19 +22,5 @@ gradlePlugin {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation "com.android.tools.build:gradle:3.1.2"
-}
-
-pluginBundle {
-    website = 'https://github.com/willir/cargo-ndk-android-gradle'
-    vcsUrl = 'https://github.com/willir/cargo-ndk-android-gradle.git'
-
-    plugins {
-        cargoNdkAndroidPlugin {
-            id = 'com.github.willir.rust.cargo-ndk-android'
-            displayName = 'Plugin for building Rust via Cargo NDK in Android projects'
-            description = 'A plugin that helps build Rust JNI libraries via Cargo NDK for use in Android projects.'
-            tags = ['rust', 'cargo', 'cargo-ndk', 'android']
-        }
-    }
+    implementation "com.android.tools.build:gradle:7.2.1"
 }

--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
@@ -45,8 +45,14 @@ class CargoNdkBuildTask extends DefaultTask {
 
         def cmd = ["cargo", "ndk",
                    "--target", target.rustTarget,
-                   "--platform", ndkVersion.toString(),
-                   "--", "build"]
+                   "--platform", ndkVersion.toString()]
+                   
+        if (config.extraCargoNdkArguments != null) {
+            cmd.addAll(config.extraCargoNdkArguments)
+        }
+
+        cmd.addAll(["--", "build"])
+
         if (config.offline) {
             cmd.add("--offline")
         }

--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkConfig.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkConfig.groovy
@@ -15,6 +15,7 @@ class CargoNdkConfig {
     private Integer apiLevel = null
     Boolean offline = null
     private String buildType = null
+    ArrayList<String> extraCargoNdkArguments = null
     ArrayList<String> extraCargoBuildArguments = null
     Map<String, String> extraCargoEnv = null
     private Boolean verbose = null
@@ -33,6 +34,7 @@ class CargoNdkConfig {
         this.apiLevel = ext.apiLevel
         this.offline = ext.offline
         this.buildType = ext.buildType
+        this.extraCargoNdkArguments = ext.extraCargoNdkArguments
         this.extraCargoBuildArguments = ext.extraCargoBuildArguments
         this.extraCargoEnv = ext.extraCargoEnv
         this.verbose = ext.verbose

--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkExtension.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkExtension.groovy
@@ -12,6 +12,7 @@ class CargoNdkExtension {
     Integer apiLevel = null
     boolean offline = false
     String buildType = "release"
+    ArrayList<String> extraCargoNdkArguments = null
     ArrayList<String> extraCargoBuildArguments = null
     Map<String, String> extraCargoEnv = null
     boolean verbose = false


### PR DESCRIPTION
I want to be able to deploy non-stripped library files for debugging purposes, so I added a configuration parameter `extraCargoNdkArguments` that lets me pass `--no-strip` to `cargo ndk`.