### PR TITLE
Updating to use Gradle 7.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,21 @@ via not rebuilding targets that are not used during testing.
 To get the full error message in Android Studio - select the `build` tab at
 the bottom of Android Studio, and then select the topmost error group
 (`Build: failed at`); it should show you the full log.
+
+
+### Local Development
+Clone the `cargo-ndk-android-gradle` repo to `<local_path>/cargo-ndk-android-gradle`
+
+In your Android project:
+* Update settings.gradle.kts to add `includeBuild` to `pluginManagement`
+
+```kotlin
+pluginManagement {
+    includeBuild("<local_path>/cargo-ndk-android-gradle")
+
+```
+* Add `cargo-ndk` to `gradle/libs.versions.toml`
+```toml
+cargo-ndk = { id = "com.github.willir.rust.cargo-ndk-android" }
+```
+

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -13,7 +13,7 @@ buildscript {
 subprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'com.gradle.plugin-publish' version '0.21.0'
 }
 
 version = "0.3.4"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,17 +1,23 @@
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '2.1.0'
 }
 
 version = "0.3.4"
 group = "com.github.willir.rust"
 
 gradlePlugin {
+    website = 'https://github.com/willir/cargo-ndk-android-gradle'
+    vcsUrl = 'https://github.com/willir/cargo-ndk-android-gradle.git'
+
     plugins {
         cargoNdkAndroidPlugin {
             id = 'com.github.willir.rust.cargo-ndk-android'
             implementationClass = 'com.github.willir.rust.CargoNdkBuildPlugin'
+            displayName = 'Plugin for building Rust via Cargo NDK in Android projects'
+            description = 'A plugin that helps build Rust JNI libraries via Cargo NDK for use in Android projects.'
+            tags.set(['rust', 'cargo', 'cargo-ndk', 'android'])
         }
     }
 }
@@ -20,18 +26,4 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation "com.android.tools.build:gradle:7.2.2"
-}
-
-pluginBundle {
-    website = 'https://github.com/willir/cargo-ndk-android-gradle'
-    vcsUrl = 'https://github.com/willir/cargo-ndk-android-gradle.git'
-
-    plugins {
-        cargoNdkAndroidPlugin {
-            id = 'com.github.willir.rust.cargo-ndk-android'
-            displayName = 'Plugin for building Rust via Cargo NDK in Android projects'
-            description = 'A plugin that helps build Rust JNI libraries via Cargo NDK for use in Android projects.'
-            tags = ['rust', 'cargo', 'cargo-ndk', 'android']
-        }
-    }
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -19,7 +19,7 @@ gradlePlugin {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation "com.android.tools.build:gradle:3.1.2"
+    implementation "com.android.tools.build:gradle:7.2.2"
 }
 
 pluginBundle {

--- a/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
+++ b/plugin/src/main/groovy/com/github/willir/rust/CargoNdkBuildTask.groovy
@@ -4,17 +4,22 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecException
+import javax.inject.Inject
 
 import java.nio.file.Files
 import java.nio.file.Path
 import groovy.json.JsonSlurper
 
-class CargoNdkBuildTask extends DefaultTask {
+abstract class CargoNdkBuildTask extends DefaultTask {
     @Input String variant
     @Input CargoNdkExtension extension
 
     private CargoNdkConfig config
+
+    @Inject
+    protected abstract ExecOperations getExecOperations()
 
     @TaskAction
     void buildRust() {
@@ -72,7 +77,7 @@ class CargoNdkBuildTask extends DefaultTask {
         }
         logger.info("Executing: ${cmd} from ${cwd} with extra env: ${extraEnv}")
 
-        project.exec {
+        execOperations.exec {
             workingDir = cwd
             commandLine = cmd
             environment extraEnv
@@ -110,7 +115,7 @@ class CargoNdkBuildTask extends DefaultTask {
 
         def os = new ByteArrayOutputStream()
 
-        project.exec {
+        execOperations.exec {
             workingDir = cargoDirPath
             commandLine = cmd
             standardOutput = os
@@ -161,7 +166,7 @@ class CargoNdkBuildTask extends DefaultTask {
         int exitValue
         def os = new ByteArrayOutputStream()
         try {
-            def p = project.exec {
+            def p = execOperations.exec {
                 commandLine = cmd
                 standardOutput = os
                 errorOutput = os

--- a/plugin/src/main/resources/META-INF/gradle-plugins/com.github.willir.rust.cargo-ndk-android.properties
+++ b/plugin/src/main/resources/META-INF/gradle-plugins/com.github.willir.rust.cargo-ndk-android.properties
@@ -1,1 +1,0 @@
-implementation-class=com.github.willir.rust.CargoNdkBuildPlugin


### PR DESCRIPTION
The plugin is not compatible with a project created in the latest Android Studio version (Android Gradle plugin v9.2.1). I've updated the plugin to use Gradle 7.3.3. I've also added a section to the README to help with Local Development.